### PR TITLE
Add log pr comment analyzer template

### DIFF
--- a/.github/workflows/log-pr-comment-analyzer.yml
+++ b/.github/workflows/log-pr-comment-analyzer.yml
@@ -6,6 +6,11 @@ on:
       prUrl:
         required: true
         type: string
+    secrets:
+      clientId:
+        required: true
+      clientSecret:
+        required: true
 
 jobs:
   log-pr-comment-analyzer:
@@ -13,8 +18,8 @@ jobs:
     env:
       ANALYZE_PR_ENDPOINT: ${{ vars.AI_LOG_AGENT_URL }}/analyze-pr-merge
       TOKEN_URL: ${{ vars.AI_LOG_AGENT_TOKEN_URL }}
-      CLIENT_ID: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}
-      CLIENT_SECRET: ${{ secrets.AI_LOG_AGENT_CLIENT_SECRET }}
+      CLIENT_ID: ${{ secrets.clientId }}
+      CLIENT_SECRET: ${{ secrets.clientSecret }}
       PR_URL: ${{ inputs.prUrl }}
 
     steps:
@@ -36,4 +41,4 @@ jobs:
             --header "Content-Type: application/json" \
             --header "Authorization: Bearer "$access_token"" \
             --data "{\"prUrl\": \"$PR_URL\"}"
-          echo "PR review request sent successfully."
+          echo "PR merge analyzed successfully."

--- a/.github/workflows/log-pr-comment-analyzer.yml
+++ b/.github/workflows/log-pr-comment-analyzer.yml
@@ -1,0 +1,50 @@
+name: Log PR Comment Analyzer Template
+
+on:
+  workflow_call:
+    inputs:
+      analyzePrEndpoint:
+        required: true
+        type: string
+      tokenUrl:
+        required: true
+        type: string
+      prUrl:
+        required: true
+        type: string
+    secrets:
+      clientId:
+        required: true
+      clientSecret:
+        required: true
+
+jobs:
+  log-pr-comment-analyzer:
+    runs-on: ubuntu-latest
+    env:
+      ANALYZE_PR_ENDPOINT: ${{ inputs.analyzePrEndpoint }}
+      TOKEN_URL: ${{ inputs.tokenUrl }}
+      CLIENT_ID: ${{ secrets.clientId }}
+      CLIENT_SECRET: ${{ secrets.clientSecret }}
+      PR_URL: ${{ inputs.prUrl }}
+
+    steps:
+      - name: Analyze PR Comments
+        run: |
+          response=$(curl --silent --request POST "$TOKEN_URL" \
+            --header "Content-Type: application/x-www-form-urlencoded" \
+            --data "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET")
+          
+          access_token=$(echo "$response" | jq -r '.access_token')
+
+          if [ "$access_token" == "null" ] || [ -z "$access_token" ]; then
+            echo "Failed to retrieve access token"
+            exit 1
+          fi
+
+          set -e
+          curl --fail --silent --show-error --location "$ANALYZE_PR_ENDPOINT" \
+            --header "Content-Type: application/json" \
+            --header "Authorization: Bearer "$access_token"" \
+            --data "{\"prUrl\": \"$PR_URL\"}"
+          echo "PR review request sent successfully."

--- a/.github/workflows/log-pr-comment-analyzer.yml
+++ b/.github/workflows/log-pr-comment-analyzer.yml
@@ -3,29 +3,18 @@ name: Log PR Comment Analyzer Template
 on:
   workflow_call:
     inputs:
-      analyzePrEndpoint:
-        required: true
-        type: string
-      tokenUrl:
-        required: true
-        type: string
       prUrl:
         required: true
         type: string
-    secrets:
-      clientId:
-        required: true
-      clientSecret:
-        required: true
 
 jobs:
   log-pr-comment-analyzer:
     runs-on: ubuntu-latest
     env:
-      ANALYZE_PR_ENDPOINT: ${{ inputs.analyzePrEndpoint }}
-      TOKEN_URL: ${{ inputs.tokenUrl }}
-      CLIENT_ID: ${{ secrets.clientId }}
-      CLIENT_SECRET: ${{ secrets.clientSecret }}
+      ANALYZE_PR_ENDPOINT: ${{ vars.AI_LOG_AGENT_URL }}/analyze-pr-merge
+      TOKEN_URL: ${{ vars.AI_LOG_AGENT_TOKEN_URL }}
+      CLIENT_ID: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}
+      CLIENT_SECRET: ${{ secrets.AI_LOG_AGENT_CLIENT_SECRET }}
       PR_URL: ${{ inputs.prUrl }}
 
     steps:

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -22,7 +22,7 @@ jobs:
   log-pr-review:
     runs-on: ubuntu-latest
     env:
-      REVIEW_ENDPOINT: ${{ inputs.reviewEndpoint }}
+      REVIEW_ENDPOINT: ${{ vars.AI_LOG_AGENT_URL }}/review-pr
       TOKEN_URL: ${{ inputs.tokenUrl }}
       CLIENT_ID: ${{ secrets.clientId }}
       CLIENT_SECRET: ${{ secrets.clientSecret }}

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -3,12 +3,6 @@ name: Log PR Reviewer Template
 on:
   workflow_call:
     inputs:
-      reviewEndpoint:
-        required: true
-        type: string
-      tokenUrl:
-        required: true
-        type: string
       prUrl:
         required: true
         type: string
@@ -23,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REVIEW_ENDPOINT: ${{ vars.AI_LOG_AGENT_URL }}/review-pr
-      TOKEN_URL: ${{ inputs.tokenUrl }}
+      TOKEN_URL: ${{ vars.AI_LOG_AGENT_TOKEN_URL }}
       CLIENT_ID: ${{ secrets.clientId }}
       CLIENT_SECRET: ${{ secrets.clientSecret }}
       PR_URL: ${{ inputs.prUrl }}


### PR DESCRIPTION
## Purpose
Add log pr comment analyzer template for M2


This pull request introduces a new GitHub Actions workflow file to automate the analysis of pull request comments. The workflow is designed to send a request to an external endpoint for PR comment analysis, using OAuth2 for authentication.

### New GitHub Actions workflow:

* [`.github/workflows/log-pr-comment-analyzer.yml`](diffhunk://#diff-ab8d1c48027cc34c29131aba70591bf017d962b7657dddf6c2910a7166fb1482R1-R50): Added a workflow named "Log PR Comment Analyzer Template" that accepts inputs for the analysis endpoint, token URL, and PR URL. It retrieves an OAuth2 access token using provided client credentials and sends a POST request to the analysis endpoint with the PR URL. The workflow ensures proper error handling for token retrieval and request execution.

Secrets cannot be accessed from reusable workflows
<img width="877" height="156" alt="Screenshot 2025-07-15 at 14 16 01" src="https://github.com/user-attachments/assets/c2989d1e-95ef-4e26-8fce-e4bb8f4f3895" />
